### PR TITLE
Incorporate version pinning in `dist` builds

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -6,6 +6,7 @@ name: Build and Deploy to Dist Branch
 on:
   push:
     branches: [ master ]
+    paths: [ 'gadgets/**/*.+(js|ts|css|less|json|yaml)' ]
   # Allow manual triggering from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -48,7 +48,16 @@ jobs:
     
     - name: Set environment variables
       run: |
-        echo "CDN_ENTRYPOINT=https://cdn.jsdelivr.net/gh/${{ github.repository }}@dist/dist" >> $GITHUB_ENV
+        # Bump semver
+        LATEST_TAG=$(git describe --abbrev=0 --candidates=1 $(git rev-parse --short origin/dist)) 	# by timestamp
+        SEMVER=${LATEST_TAG#v}
+        IFS='.' read -r SEMVER_MAJOR SEMVER_MINOR SEMVER_PATCH <<< "$SEMVER"
+        SEMVER_PATCH=$((SEMVER_PATCH + 1))
+        NEW_TAG="v$SEMVER_MAJOR.$SEMVER_MINOR.$SEMVER_PATCH"
+        echo "NEW_TAG=$NEW_TAG" >> $GITHUB_ENV
+
+        # Set CDN entrypoint with version pinning
+        echo "CDN_ENTRYPOINT=https://cdn.jsdelivr.net/gh/${{ github.repository }}@$NEW_TAG/dist" >> $GITHUB_ENV
 
     - name: Publish build result to dist branch
       run: |

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -48,12 +48,7 @@ jobs:
     
     - name: Set environment variables
       run: |
-        # Bump semver
-        LATEST_TAG=$(git describe --abbrev=0 --candidates=1 $(git rev-parse --short origin/dist)) 	# by timestamp
-        SEMVER=${LATEST_TAG#v}
-        IFS='.' read -r SEMVER_MAJOR SEMVER_MINOR SEMVER_PATCH <<< "$SEMVER"
-        SEMVER_PATCH=$((SEMVER_PATCH + 1))
-        NEW_TAG="v$SEMVER_MAJOR.$SEMVER_MINOR.$SEMVER_PATCH"
+        NEW_TAG="$(date +%s)"
         echo "NEW_TAG=$NEW_TAG" >> $GITHUB_ENV
 
         # Set CDN entrypoint with version pinning

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -30,6 +30,14 @@ jobs:
         node-version: '22'
         cache: 'npm'
     
+    - name: Cache Node.js modules
+      uses: actions/cache@v4
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-modules-
+    
     - name: Install dependencies
       run: npm ci
     
@@ -38,10 +46,14 @@ jobs:
         git config --global user.name 'github-actions[bot]'
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
     
+    - name: Set environment variables
+      run: |
+        echo "CDN_ENTRYPOINT=https://cdn.jsdelivr.net/gh/${{ github.repository }}@dist/dist" >> $GITHUB_ENV
+
     - name: Publish build result to dist branch
       run: |
         bash ./publish.sh
-
+  
   sync-with-dev:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -62,6 +62,8 @@ jobs:
         bash ./publish.sh
   
   sync-with-dev:
+    if: ${{ github.repository == 'lihaohong6/MirahezeDevScripts' }}
+
     runs-on: ubuntu-latest
 
     needs: build-and-deploy

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -6,7 +6,9 @@ name: Build and Deploy to Dist Branch
 on:
   push:
     branches: [ master ]
-    paths: [ 'gadgets/**/*.+(js|ts|css|less|json|yaml)' ]
+    paths: 
+      - 'gadgets/**'
+      - '!gadgets/**.md'
   # Allow manual triggering from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -9,6 +9,9 @@ on:
     paths: 
       - 'gadgets/**'
       - '!gadgets/**.md'
+      - 'dev-utils/**'
+      - 'plugins/**'
+      - 'package.json'
   # Allow manual triggering from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -6,12 +6,12 @@ name: Build and Deploy to Dist Branch
 on:
   push:
     branches: [ master ]
-    paths: 
-      - 'gadgets/**'
-      - '!gadgets/**.md'
-      - 'dev-utils/**'
-      - 'plugins/**'
-      - 'package.json'
+    paths:
+      - "gadgets/**"
+      - "!gadgets/**.md"
+      - "dev-utils/**"
+      - "plugins/**"
+      - "package.json"
   # Allow manual triggering from the Actions tab
   workflow_dispatch:
 
@@ -21,49 +21,41 @@ permissions:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - name: Checkout master branch
-      uses: actions/checkout@v4
-      with:
-        ref: master
-        fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
-    
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '22'
-        cache: 'npm'
-    
-    - name: Cache Node.js modules
-      uses: actions/cache@v4
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-modules-
-    
-    - name: Install dependencies
-      run: npm ci
-    
-    - name: Configure Git
-      run: |
-        git config --global user.name 'github-actions[bot]'
-        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-    
-    - name: Set environment variables
-      run: |
-        NEW_TAG="$(date +%s)"
-        echo "NEW_TAG=$NEW_TAG" >> $GITHUB_ENV
+      - name: Checkout master branch
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-        # Set CDN entrypoint with version pinning
-        echo "CDN_ENTRYPOINT=https://cdn.jsdelivr.net/gh/${{ github.repository }}@$NEW_TAG/dist" >> $GITHUB_ENV
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
 
-    - name: Publish build result to dist branch
-      run: |
-        bash ./publish.sh
-  
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Configure Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Set environment variables
+        run: |
+          NEW_TAG="$(date +%s)"
+          echo "NEW_TAG=$NEW_TAG" >> $GITHUB_ENV
+
+          # Set CDN entrypoint with version pinning
+          echo "CDN_ENTRYPOINT=https://cdn.jsdelivr.net/gh/${{ github.repository }}@$NEW_TAG/dist" >> $GITHUB_ENV
+
+      - name: Publish build result to dist branch
+        run: |
+          bash ./publish.sh
+
   sync-with-dev:
     if: ${{ github.repository == 'lihaohong6/MirahezeDevScripts' }}
 
@@ -72,33 +64,33 @@ jobs:
     needs: build-and-deploy
 
     steps:
-    - name: Checkout all branches
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout all branches
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Get latest commit hash from dist branch
-      id: dist-hash
-      run: |
-        git fetch origin dist
-        HASH=$(git rev-parse origin/dist)
-        echo "dist_hash=$HASH" >> $GITHUB_ENV
+      - name: Get latest commit hash from dist branch
+        id: dist-hash
+        run: |
+          git fetch origin dist
+          HASH=$(git rev-parse origin/dist)
+          echo "dist_hash=$HASH" >> $GITHUB_ENV
 
-    - name: Switch to master branch
-      run: |
-        git checkout master
+      - name: Switch to master branch
+        run: |
+          git checkout master
 
-    - name: Set up Python with uv
-      run: |
-        pip install uv
+      - name: Set up Python with uv
+        run: |
+          pip install uv
 
-    - name: Run dev-sync script
-      env:
-        CONSUMER_TOKEN: ${{ secrets.CONSUMER_TOKEN }}
-        CONSUMER_SECRET: ${{ secrets.CONSUMER_SECRET }}
-        ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        ACCESS_SECRET: ${{ secrets.ACCESS_SECRET }}
-      run: |
-        cd dev-sync
-        uv run main.py $dist_hash $CONSUMER_TOKEN $CONSUMER_SECRET $ACCESS_TOKEN $ACCESS_SECRET
+      - name: Run dev-sync script
+        env:
+          CONSUMER_TOKEN: ${{ secrets.CONSUMER_TOKEN }}
+          CONSUMER_SECRET: ${{ secrets.CONSUMER_SECRET }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          ACCESS_SECRET: ${{ secrets.ACCESS_SECRET }}
+        run: |
+          cd dev-sync
+          uv run main.py $dist_hash $CONSUMER_TOKEN $CONSUMER_SECRET $ACCESS_TOKEN $ACCESS_SECRET

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,6 +3,7 @@
 module.exports = function ( grunt ) {
 	grunt.loadNpmTasks( 'grunt-eslint' );
 	grunt.loadNpmTasks( 'grunt-stylelint' );
+	grunt.loadNpmTasks( 'grunt-json-minify' );
 
 	grunt.initConfig( {
 		eslint: {
@@ -22,6 +23,15 @@ module.exports = function ( grunt ) {
 				'!vendor/**',
 				'!dist/**',
 			]
+		},
+		"json-minify": {
+			build: {
+				files: "dist/**/*.json"
+			},
+			options: {
+				skipOnError: true,
+				encoding: "utf-8"
+			}
 		}
 	} );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "eslint-config-wikimedia": "^0.31.0",
         "grunt": "^1.6.1",
         "grunt-eslint": "^24.0.0",
+        "grunt-json-minify": "^1.1.0",
         "grunt-stylelint": "^0.20.1",
         "jiti": "^2.6.1",
         "less": "^4.4.1",
@@ -4213,6 +4214,15 @@
       },
       "peerDependencies": {
         "grunt": ">=1"
+      }
+    },
+    "node_modules/grunt-json-minify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-json-minify/-/grunt-json-minify-1.1.0.tgz",
+      "integrity": "sha512-JQae6Fr6wT19cres4jh24uyiMggDv6I/uPpU9w5c9zu2no05VgBvghPZiIulUiFFlFcRh+4828QCHrSoJ8JQKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/grunt-known-options": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "eslint-config-wikimedia": "^0.31.0",
     "grunt": "^1.6.1",
     "grunt-eslint": "^24.0.0",
+    "grunt-json-minify": "^1.1.0",
     "grunt-stylelint": "^0.20.1",
     "jiti": "^2.6.1",
     "less": "^4.4.1",

--- a/publish.sh
+++ b/publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 DIST_DIR="dist"
 TARGET_BRANCH="dist"
-npm run build
+npm run build && npx grunt json-minify
 TEMP_DIR=$(mktemp -d)
 cp -r "$DIST_DIR" "$TEMP_DIR/dist"
 git switch "$TARGET_BRANCH"
@@ -11,4 +11,3 @@ git add .
 git commit -m "Recompile gadget"
 git push
 git switch master
-

--- a/publish.sh
+++ b/publish.sh
@@ -10,4 +10,11 @@ cp -r "$TEMP_DIR/dist" "$DIST_DIR"
 git add .
 git commit -m "Recompile gadget"
 git push
+
+# Push new tag
+if [[ -v NEW_TAG ]]; then
+  git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+  git push origin $NEW_TAG
+fi
+
 git switch master

--- a/publish.sh
+++ b/publish.sh
@@ -13,7 +13,7 @@ git push
 
 # Push new tag
 if [[ -v NEW_TAG ]]; then
-  git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+  git tag -a "$NEW_TAG" -m "Build & deploy at timestamp: $NEW_TAG"
   git push origin $NEW_TAG
 fi
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,14 +26,15 @@ export default defineConfig(async ({ mode }: ConfigEnv): Promise<UserConfig> => 
   const { 
     GADGET_NAMESPACE: gadgetNamespace = 'ext.gadget.store',
     SERVER_DEV_ORIGIN: serverDevOrigin = 'http://localhost:5173',
-    SERVER_PREVIEW_ORIGIN: serverPreviewOrigin = 'http://localhost:4173',
+    CDN_ENTRYPOINT: cdnEntrypoint = 'http://localhost:4173',
+    SERVER_PREVIEW_ORIGIN: serverPreviewOrigin,
   } = env;
   
   const isDev = mode === 'development';
   if (isDev) { 
     setViteServerOrigin(serverDevOrigin); 
   } else {
-    setViteServerOrigin(serverPreviewOrigin);
+    setViteServerOrigin(serverPreviewOrigin || cdnEntrypoint);
   }
   setGadgetNamespace(gadgetNamespace);
     


### PR DESCRIPTION
*No other PR is required to be merged before this PR*

Apply several changes to `.github/workflows/build-dist.yml` and `publish.sh` to do the following:
 - Cache Node.js modules on every `build-and-deploy` run.
 - Only run the `build-and-deploy` run when files in `gadgets/` (including `gadgets-definition.yaml`), `dev-utils/`, `plugins/`, or the `package.json` file, are changed.
 - Skip the `build-and-deploy` run if .md files in `gadgets/` are changed.
 - Skip the `sync-with-dev` step on forked repos.
 - Automatically apply a Git tag and create a release on every `build-and-deploy` run based on Unix timestamp.
 - Inject the environment `CDN_ENTRYPOINT` during `npm run build` that corresponds to each Git tag release. This may be used to get the gadgets to call other gadgets **in the same build** only.
 - Run `grunt json minify` to minify all json asset files.