### PR TITLE
jswikibot: implement wakelocks on progress_window

### DIFF
--- a/gadgets/jswikibot/config.ts
+++ b/gadgets/jswikibot/config.ts
@@ -35,6 +35,7 @@ export class SettingsDialog extends OO.ui.ProcessDialog {
     private summaryInput!: OO.ui.TextInputWidget;
     private readThrottleInput!: OO.ui.NumberInputWidget;
     private writeThrottleInput!: OO.ui.NumberInputWidget;
+    private wakeLockEnabledInput!: OO.ui.CheckboxInputWidget;
 
     public initialize(): this {
         super.initialize();
@@ -52,6 +53,11 @@ export class SettingsDialog extends OO.ui.ProcessDialog {
             min: 0.5,
             max: 20
         });
+        
+        this.wakeLockEnabledInput = new OO.ui.CheckboxInputWidget({
+            selected: state.config.wakeLockEnabled,
+            disabled: !("wakeLock" in navigator)
+        });
 
         const fieldset = new OO.ui.FieldsetLayout({ label: 'Global Bot Configuration' });
         fieldset.addItems([
@@ -61,6 +67,7 @@ export class SettingsDialog extends OO.ui.ProcessDialog {
             new OO.ui.FieldLayout(this.readThrottleInput, { label: 'Read throttle (0.1s to 10s)', align: 'top' }),
             // @ts-expect-error This works as a widget
             new OO.ui.FieldLayout(this.writeThrottleInput, { label: 'Write throttle (0.5s to 20s)', align: 'top' }),
+            new OO.ui.FieldLayout(this.wakeLockEnabledInput, { label: 'Wakelock enabled', align: 'inline'})
         ]);
 
         const mainPanel = new OO.ui.PanelLayout({ padded: true, expanded: false });
@@ -77,6 +84,7 @@ export class SettingsDialog extends OO.ui.ProcessDialog {
                 state.config.summaryBot = this.summaryInput.getValue();
                 state.config.readThrottle = Number(this.readThrottleInput.getValue());
                 state.config.writeThrottle = Number(this.writeThrottleInput.getValue());
+                state.config.wakeLockEnabled = this.wakeLockEnabledInput.isSelected();
 
                 // Persist to local storage
                 saveConfig();

--- a/gadgets/jswikibot/config.ts
+++ b/gadgets/jswikibot/config.ts
@@ -67,7 +67,7 @@ export class SettingsDialog extends OO.ui.ProcessDialog {
             new OO.ui.FieldLayout(this.readThrottleInput, { label: 'Read throttle (0.1s to 10s)', align: 'top' }),
             // @ts-expect-error This works as a widget
             new OO.ui.FieldLayout(this.writeThrottleInput, { label: 'Write throttle (0.5s to 20s)', align: 'top' }),
-            new OO.ui.FieldLayout(this.wakeLockEnabledInput, { label: 'Wakelock enabled', align: 'inline'})
+            new OO.ui.FieldLayout(this.wakeLockEnabledInput, { label: 'Wakelock enabled', help: 'Keep screen on during bot activity', align: 'inline'})
         ]);
 
         const mainPanel = new OO.ui.PanelLayout({ padded: true, expanded: false });

--- a/gadgets/jswikibot/models/state.ts
+++ b/gadgets/jswikibot/models/state.ts
@@ -16,6 +16,8 @@ export class Config {
     // In seconds
     readThrottle: number = 0.2;
     writeThrottle: number = 1;
+    // Whether a wakelock is held while the bot is executing actions
+    wakeLockEnabled: boolean = true
 }
 
 class State {
@@ -27,6 +29,10 @@ export const state = new State();
 
 export function isDebugMode() {
     return state.config.debug;
+}
+
+export function isWakeLockEnabled() {
+    return state.config.wakeLockEnabled;
 }
 
 export function cachePageInfo(pageInfo: PageInfo) {

--- a/gadgets/jswikibot/models/state.ts
+++ b/gadgets/jswikibot/models/state.ts
@@ -17,7 +17,7 @@ export class Config {
     readThrottle: number = 0.2;
     writeThrottle: number = 1;
     // Whether a wakelock is held while the bot is executing actions
-    wakeLockEnabled: boolean = true
+    wakeLockEnabled: boolean = true;
 }
 
 class State {

--- a/gadgets/jswikibot/utils/progress_window.ts
+++ b/gadgets/jswikibot/utils/progress_window.ts
@@ -209,8 +209,10 @@ export class ProgressWindow {
 
     requestWakeLock() {
         navigator.wakeLock.request("screen").then((wakeLock: WakeLockSentinel) => {
-            this.wakeLock = wakeLock
-            if (isDebugMode()) this.addLog(LogSeverity.INFO, `Wake lock requested`)
+            this.wakeLock = wakeLock;
+            if (isDebugMode()) {
+                this.addLog(LogSeverity.INFO, `Wake lock requested`);
+            }
         }).catch((err) => {
             this.addLog(LogSeverity.INFO, `Failed to request wake lock: ${err.name}, ${err.message}`)
         })

--- a/gadgets/jswikibot/utils/progress_window.ts
+++ b/gadgets/jswikibot/utils/progress_window.ts
@@ -37,7 +37,7 @@ export class ProgressWindow {
     private readonly logLabel: OO.ui.LabelWidget;
     private readonly cancelButton: OO.ui.ButtonWidget;
     private readonly logPanelWidget: OO.ui.Widget;
-    private wakeLock: WakeLockSentinel | null;
+    private wakeLock: WakeLockSentinel | null = null;
     private isDone = false;
     private progress = 0;
     private isCancelled = false;

--- a/gadgets/jswikibot/utils/progress_window.ts
+++ b/gadgets/jswikibot/utils/progress_window.ts
@@ -1,5 +1,5 @@
 import {openWindow} from "./alert_window";
-import {isWakeLockEnabled, isDebugMode} from "../models/state"
+import {isWakeLockEnabled, isDebugMode} from "../models/state";
 
 export enum LogSeverity {
     SUCCESS = "Success",

--- a/gadgets/jswikibot/utils/progress_window.ts
+++ b/gadgets/jswikibot/utils/progress_window.ts
@@ -228,7 +228,7 @@ export class ProgressWindow {
 
     cleanupWakeLock() {
         this.releaseWakeLock();
-        document.removeEventListener("visibilitychange", this.handleDocumentVisibilityChange)
+        document.removeEventListener("visibilitychange", this.handleDocumentVisibilityChange);
     }
 
     private readonly logEntries: LogEntry[] = [];

--- a/gadgets/jswikibot/utils/progress_window.ts
+++ b/gadgets/jswikibot/utils/progress_window.ts
@@ -214,15 +214,15 @@ export class ProgressWindow {
                 this.addLog(LogSeverity.INFO, `Wake lock requested`);
             }
         }).catch((err) => {
-            this.addLog(LogSeverity.INFO, `Failed to request wake lock: ${err.name}, ${err.message}`)
-        })
+            this.addLog(LogSeverity.INFO, `Failed to request wake lock: ${err.name}, ${err.message}`);
+        });
     }
 
     releaseWakeLock() {
         if (this.wakeLock) {
             this.wakeLock.release().then(() => {
                 this.wakeLock = null;
-            })
+            });
         }
     }
 

--- a/gadgets/jswikibot/utils/progress_window.ts
+++ b/gadgets/jswikibot/utils/progress_window.ts
@@ -147,6 +147,9 @@ export class ProgressWindow {
             size: "large"
         }, () => {
             this.cleanupWakeLock();
+            if (isDebugMode()) {
+                console.log("jswikibot: wakelock cleanup");
+            }
         });
 
         // Confirm exit when the bot is not yet done/canceled

--- a/gadgets/jswikibot/utils/progress_window.ts
+++ b/gadgets/jswikibot/utils/progress_window.ts
@@ -280,6 +280,7 @@ export class ProgressWindow {
             this.isDone = true;
             this.setProgress(this.total);
             this.hideCancelButton();
+            this.cleanupWakeLock();
         }
     }
 }

--- a/gadgets/jswikibot/utils/progress_window.ts
+++ b/gadgets/jswikibot/utils/progress_window.ts
@@ -1,4 +1,5 @@
 import {openWindow} from "./alert_window";
+import {isWakeLockEnabled, isDebugMode} from "../models/state"
 
 export enum LogSeverity {
     SUCCESS = "Success",
@@ -36,6 +37,7 @@ export class ProgressWindow {
     private readonly logLabel: OO.ui.LabelWidget;
     private readonly cancelButton: OO.ui.ButtonWidget;
     private readonly logPanelWidget: OO.ui.Widget;
+    private wakeLock: WakeLockSentinel | null;
     private isDone = false;
     private progress = 0;
     private isCancelled = false;
@@ -129,6 +131,8 @@ export class ProgressWindow {
             })
         ]);
 
+        this.initialRequestWakeLock();
+
         this.progressDialog = new OO.ui.MessageDialog();
         openWindow(this.progressDialog, {
             title: 'Bot progress',
@@ -141,6 +145,9 @@ export class ProgressWindow {
                 }
             ],
             size: "large"
+        }, () => {
+            // Cleanup wakelock
+            this.cleanupWakeLock();
         });
 
         // Confirm exit when the bot is not yet done/canceled
@@ -183,6 +190,41 @@ export class ProgressWindow {
 
     makeProgress(progress: number) {
         this.setProgress(this.progress + progress);
+    }
+
+    handleDocumentVisibilityChange = async () => {
+        if (this.wakeLock !== null && document.visibilityState === "visible") {
+            this.requestWakeLock()
+        }
+    }
+
+    initialRequestWakeLock() {
+        if (isWakeLockEnabled() && 'wakeLock' in navigator) {
+            document.addEventListener("visibilitychange", this.handleDocumentVisibilityChange);
+            this.requestWakeLock();
+        }
+    }
+
+    requestWakeLock() {
+        navigator.wakeLock.request("screen").then((wakeLock: WakeLockSentinel) => {
+            this.wakeLock = wakeLock
+            if (isDebugMode()) this.addLog(LogSeverity.INFO, `Wake lock requested`)
+        }).catch((err) => {
+            this.addLog(LogSeverity.INFO, `Failed to request wake lock: ${err.name}, ${err.message}`)
+        })
+    }
+
+    releaseWakeLock() {
+        if (this.wakeLock) {
+            this.wakeLock.release().then(() => {
+                this.wakeLock = null;
+            })
+        }
+    }
+
+    cleanupWakeLock() {
+        this.releaseWakeLock();
+        document.removeEventListener("visibilitychange", this.handleDocumentVisibilityChange)
     }
 
     private readonly logEntries: LogEntry[] = [];

--- a/gadgets/jswikibot/utils/progress_window.ts
+++ b/gadgets/jswikibot/utils/progress_window.ts
@@ -196,7 +196,7 @@ export class ProgressWindow {
 
     handleDocumentVisibilityChange = async () => {
         if (this.wakeLock !== null && document.visibilityState === "visible") {
-            this.requestWakeLock()
+            this.requestWakeLock();
         }
     }
 

--- a/gadgets/jswikibot/utils/progress_window.ts
+++ b/gadgets/jswikibot/utils/progress_window.ts
@@ -146,7 +146,6 @@ export class ProgressWindow {
             ],
             size: "large"
         }, () => {
-            // Cleanup wakelock
             this.cleanupWakeLock();
         });
 


### PR DESCRIPTION
Closes #24 

Implements wakelocking when progress_window is active to prevent the screen from timing out and adds a configuration option in the bot settings to enable or disable it.